### PR TITLE
Report immediately on startup

### DIFF
--- a/agent/lib_test.go
+++ b/agent/lib_test.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/noqcks/xeol-agent/agent/inventory"
+	"github.com/noqcks/xeol-agent/internal/config"
+)
+
+func TestPeriodicallyGetInventoryReport(t *testing.T) {
+	cfg := &config.Application{
+		PollingIntervalSeconds: 1,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Duration(cfg.PollingIntervalSeconds)*time.Second)
+	defer cancel()
+
+	reportTimes := []time.Time{}
+	reportHandler := func(report inventory.Report, cfg *config.Application) error {
+		reportTimes = append(reportTimes, time.Now())
+		return nil
+	}
+
+	getInventoryReportFunc := func(cfg *config.Application) (inventory.Report, error) {
+		return inventory.Report{}, nil
+	}
+	startTime := time.Now()
+	PeriodicallyGetInventoryReport(ctx, cfg, getInventoryReportFunc, reportHandler)
+
+	if len(reportTimes) < 2 {
+		t.Fatalf("Expected at least two reports, but got %d", len(reportTimes))
+	}
+
+	firstInterval := reportTimes[0].Sub(startTime)
+	if firstInterval >= time.Duration(cfg.PollingIntervalSeconds)*time.Second {
+		t.Fatalf("Expected the first report to be immediate, but the interval was %v", firstInterval)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"runtime/pprof"
@@ -43,7 +44,8 @@ var rootCmd = &cobra.Command{
 
 		switch appConfig.RunMode {
 		case mode.PeriodicPolling:
-			agent.PeriodicallyGetInventoryReport(appConfig)
+			ctx := context.Background()
+			agent.PeriodicallyGetInventoryReport(ctx, appConfig, agent.GetInventoryReport, agent.HandleReport)
 		default:
 			report, err := agent.GetInventoryReport(appConfig)
 			if appConfig.Dev.ProfileCPU {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Application struct {
 	Mode                            string   `mapstructure:"mode"`
 	IgnoreNotRunning                bool     `mapstructure:"ignore-not-running"`
 	PollingIntervalMinutes          int      `mapstructure:"polling-interval-minutes"`
+	PollingIntervalSeconds          int      `mapstructure:"polling-interval-seconds"`
 	XeolDetails                     XeolInfo `mapstructure:"xeol"`
 }
 

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -39,6 +39,7 @@ runmode: 0
 mode: adhoc
 ignorenotrunning: true
 pollingintervalminutes: 300
+pollingintervalseconds: 0
 xeoldetails:
   apikey: '******'
   http:

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -39,6 +39,7 @@ runmode: 0
 mode: ""
 ignorenotrunning: false
 pollingintervalminutes: 0
+pollingintervalseconds: 0
 xeoldetails:
   apikey: ""
   http:

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -39,6 +39,7 @@ runmode: 0
 mode: adhoc
 ignorenotrunning: true
 pollingintervalminutes: 300
+pollingintervalseconds: 0
 xeoldetails:
   apikey: '******'
   http:


### PR DESCRIPTION
When the xeol-agent starts up for the first time, we should bypass the polling interval and report immediately. Way better UX for customers.